### PR TITLE
Run check_uniqueness before any migration

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -170,6 +170,22 @@ jobs:
         run: cd output/local && docker compose up -d
       - name: Wait for LAVA 2023.10 to be started
         run: sh .github/workflows/wait-for-docker.sh
+      - name: Run backup of 2023.10
+        run: ./backup.sh
+      - name: stop docker
+        run: cd output/local && docker compose down
+      - name: Clean old install
+        run: rm -r output
+      - name: Copy backup
+        run: cp -v backup-latest/* lava-master/backup/
+      - name: Run lavalab-gen
+        run: ./lavalab-gen.py boards-ci.yaml
+      - name: Build lava-docker Last
+        run: cd output/local && docker compose build
+      - name: Launch lava-docker Last
+        run: cd output/local && docker compose up -d
+      - name: Wait for LAVA Last to be started
+        run: sh .github/workflows/wait-for-docker.sh
   test-backup:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lavacli.sh
+++ b/.github/workflows/lavacli.sh
@@ -2,6 +2,9 @@
 
 . output/.env
 
+sleep 20
+
+echo "DEBUG: lavacli: called with $*"
 # verify all devices and jobs are ok
 if [ "$1" = "health" ];then
 	FTMP='/tmp/jobs'

--- a/.github/workflows/wait-for-docker.sh
+++ b/.github/workflows/wait-for-docker.sh
@@ -48,7 +48,7 @@ while [ $TIMEOUT -le 1200 ]
 do
 	need_wait
 	RET=$?
-	docker compose logs --tail=60
+	#docker compose logs --tail=60
 	docker ps > /tmp/alldocker
 	grep -q $DOCKERNAME /tmp/alldocker
 	if [ $? -ne 0 ];then
@@ -61,6 +61,7 @@ do
 		exit 1
 	fi
 	if [ $RET -eq 0 ];then
+		docker compose logs
 		exit 0
 	fi
 	sleep 10

--- a/lava-master/entrypoint.d/01_setup.sh
+++ b/lava-master/entrypoint.d/01_setup.sh
@@ -69,6 +69,17 @@ if [ $? -eq 0 ];then
 	lava-server manage makemigrations
 	yes yes | lava-server manage migrate || exit $?
 fi
+
+find /usr/lib/python3 |grep -q check_uniqueness.py
+if [ $? -eq 0 ];then
+	echo "DEBUG: check_uniqueness FOUND"
+	# check bug fixed in 2023.10
+	lava-server manage check_uniqueness --dry-run || exit $?
+	lava-server manage check_uniqueness --yes || exit $?
+else
+	echo "DEBUG: check_uniqueness not FOUND"
+fi
+
 # if we came from 2023.01 to 2023.05, we need to handle the migration bug
 grep -q '2023.0[1-5]' /tmp/workerversions
 if [ $? -eq 0 ];then


### PR DESCRIPTION
There was some old bug creating duplicate jobs, and some migration could fail with it.
Just ran the script which fix it before.

Add a new step for testing this patch.
Add some delay to wait for lavacli wait job as it fail sometimes since LAVA could lag a bit to start jobs.